### PR TITLE
Add "Sampling and Testing the Penguins" to "Probability and Statistics" section of the index.

### DIFF
--- a/resources/tutorials/index.md
+++ b/resources/tutorials/index.md
@@ -33,6 +33,7 @@ These notebooks are on basic Python data manipulation:
 6.  [Correlation](Correlation.ipynb)
 7.  [Regressions](Regressions.ipynb) (goes with [Week 8](../../week8/index.md))
 8.  [Logistic Regression](LogitRegressionDemo.ipynb)
+9.  [Sampling and Testing the Penguins](PenguinSamples.ipynb)
 
 ## SciKit-Learn and ML Models
 


### PR DESCRIPTION
I didn't notice "Sampling and Testing the Penguins" listed in any different index section, seems like it would fit in the "Probability and Statistics" one.